### PR TITLE
Allow scripts to locate themselves when linked to.

### DIFF
--- a/scheme-script
+++ b/scheme-script
@@ -30,7 +30,8 @@ if [ -z "$LARCENY_ROOT" ]; then
     # script.  If it's a relative path, we make it absolute.  Then, if it ends
     # in Scripts, we chop off that component.
 
-    dir="`dirname "$0"`"
+    script=`readlink -f $0`
+    dir="`dirname "$script"`"
     dir="`( cd $dir; pwd )`"
     [ "`basename "$dir"`" = Scripts ] && dir="`dirname "$dir"`"
 

--- a/src/Build/Scripts/larceny.sh
+++ b/src/Build/Scripts/larceny.sh
@@ -22,7 +22,8 @@ if [ -z "$LARCENY_ROOT" ]; then
     # script.  If it's a relative path, we make it absolute.  Then, if it ends
     # in Scripts, we chop off that component.
 
-    dir="`dirname "$0"`"
+    script=`readlink -f "$0"`    
+    dir="`dirname "$script"`"
     dir="`( cd $dir; pwd )`"
     [ "`basename "$dir"`" = Scripts ] && dir="`dirname "$dir"`"
 


### PR DESCRIPTION
If a user were to link to larceny and scheme-script rather than copy and edit the files then the scripts would be unable to locate themselves.

This can be overcome for bash, sh, and ksh by using readlink.

With this change users will no longer need to modify the scripts, they can link to them wherever they like.