### PR TITLE
(r6rs lists) and (r6rs control)

### DIFF
--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -18,7 +18,7 @@ List of R6RS standard libraries and their current status:
 (r6rs base)                     implemented with stub for identifier-syntax
 (r6rs unicode)                  fully implemented atop (scheme char)
 (r6rs bytevectors)              fully implemented atop (scheme base)
-(r6rs lists)                    not yet implemented
+(r6rs lists)                    fully implemented atop (scheme base)
 (r6rs sorting)                  not yet implemented
 (r6rs control)                  not yet implemented
 (r6rs records syntactic)        will wait for R7RS (large)

--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -20,7 +20,7 @@ List of R6RS standard libraries and their current status:
 (r6rs bytevectors)              fully implemented atop (scheme base)
 (r6rs lists)                    fully implemented atop (scheme base)
 (r6rs sorting)                  not yet implemented
-(r6rs control)                  not yet implemented
+(r6rs control)                  fully implemented atop (scheme base)
 (r6rs records syntactic)        will wait for R7RS (large)
 (r6rs records procedural)       will wait for R7RS (large)
 (r6rs records inspection)       will wait for R7RS (large)

--- a/tools/R6RS/r6rs/control.sld
+++ b/tools/R6RS/r6rs/control.sld
@@ -1,0 +1,3 @@
+(define-library (r6rs control)
+  (export when unless do case-lambda)
+  (import (scheme base) (scheme case-lambda)))

--- a/tools/R6RS/r6rs/lists.body.scm
+++ b/tools/R6RS/r6rs/lists.body.scm
@@ -1,0 +1,145 @@
+;;; Copyright 2015 Taylan Ulrich Bayırlı/Kammer <taylanbayirli@gmail.com>.
+;;;
+;;; Permission to copy this software, in whole or in part, to use this
+;;; software for any lawful purpose, and to redistribute this software
+;;; is granted subject to the restriction that all copies made of this
+;;; software must include this copyright and permission notice in full.
+;;;
+;;; I also request that you send me a copy of any improvements that you
+;;; make to this software so that they may be incorporated within it to
+;;; the benefit of the Scheme community.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (identity x) x)
+
+(define (find proc list)
+  (let loop ((rest list))
+    (if (null? rest)
+        #f
+        (let ((car (car rest)))
+          (if (proc car)
+              car
+              (loop (cdr rest)))))))
+
+(define-syntax define-quantifier
+  (syntax-rules ()
+    ((_ <name> <base-value> <terminating-value?>)
+     (define (<name> proc list1 . lists)
+       (define (length-error)
+         (error "Lists don't have the same length." (cons list1 lists)))
+       (if (null? list1)
+           ;; Careful with recursion on for-all.
+           (if (or (null? lists) (for-all null? lists))
+               <base-value>
+               (length-error))
+           (let loop ((car1 (car list1))
+                      (cars (map car lists))
+                      (cdr1 (cdr list1))
+                      (cdrs (map cdr lists)))
+             (if (null? cdr1)
+                 (if (for-all null? cdrs)
+                     (apply proc car1 cars)
+                     (length-error))
+                 (let ((value (apply proc car1 cars)))
+                   (if (<terminating-value?> value)
+                       value
+                       (loop (car cdr1) (map car cdrs)
+                             (cdr cdr1) (map cdr cdrs)))))))))))
+
+(define-quantifier for-all #t not)
+(define-quantifier exists #f identity)
+
+(define-syntax define-segregator
+  (syntax-rules ()
+    ((_ <name> <gather-negatives?>)
+     (define (<name> proc list)
+       (let loop ((rest list)
+                  (positives '())
+                  (negatives '()))
+         (if (null? rest)
+             (if <gather-negatives?>
+                 (values (reverse positives) (reverse negatives))
+                 (reverse positives))
+             (let* ((car (car rest))
+                    (pass? (proc car)))
+               (loop (cdr rest)
+                     (if pass?
+                         (cons car positives)
+                         positives)
+                     (if (and <gather-negatives?> (not pass?))
+                         (cons car negatives)
+                         negatives)))))))))
+
+(define-segregator filter #f)
+(define-segregator partition #t)
+
+(define (fold-left combine nil list1 . lists)
+  (define (length-error)
+    (error "Lists don't have the same length." (cons list1 lists)))
+  (let loop ((acc nil)
+             (list1 list1)
+             (lists lists))
+    (if (null? list1)
+        (if (for-all null? lists)
+            acc
+            (length-error))
+        (loop (apply combine acc (car list1) (map car lists))
+              (cdr list1)
+              (map cdr lists)))))
+
+(define (fold-right combine nil list1 . lists)
+  (define (length-error)
+    (error "Lists don't have the same length." (cons list1 lists)))
+  (let recur ((list1 list1)
+              (lists lists))
+    (if (null? list1)
+        (if (for-all null? lists)
+            nil
+            (length-error))
+        (let* ((acc (recur (cdr list1) (map cdr lists))))
+          (apply combine
+                 (car list1) (append (map car lists) (list acc)))))))
+
+(define-syntax define-remover
+  (syntax-rules ()
+    ((_ <name> <pred>)
+     (define (<name> obj list)
+       (let loop ((rest list)
+                  (result '()))
+         (if (null? rest)
+             (reverse result)
+             (loop (cdr rest)
+                   (let ((car (car rest)))
+                     (if (not (<pred> obj car))
+                         (cons car result)
+                         result)))))))))
+
+(define-remover remp (lambda (pred x) (pred x)))
+(define-remover remove equal?)
+(define-remover remv eqv?)
+(define-remover remq eq?)
+
+(define (memp pred list)
+  (let loop ((rest list))
+    (if (null? rest)
+        #f
+        (if (pred (car rest))
+            rest
+            (loop (cdr rest))))))
+
+(define (assp pred alist)
+  (let loop ((rest alist))
+    (if (null? rest)
+        #f
+        (let ((entry (car rest)))
+          (if (pred (car entry))
+              entry
+              (loop (cdr rest)))))))
+
+(define cons*
+  (case-lambda
+    ((obj)
+     obj)
+    (objs
+     (cons (car objs) (apply cons* (cdr objs))))))

--- a/tools/R6RS/r6rs/lists.sld
+++ b/tools/R6RS/r6rs/lists.sld
@@ -1,0 +1,15 @@
+(define-library (r6rs lists)
+  (export
+   find
+   for-all exists
+   filter partition
+   fold-left fold-right
+   remp remove remv remq
+   memp member memv memq
+   assp assoc assv assq
+   cons*
+   )
+  (import
+   (scheme base)
+   (scheme case-lambda))
+  (include "lists.body.scm"))


### PR DESCRIPTION
lists: Ran rudimentary examples from R6RS in a REPL; otherwise test suite pending.  Note that this reexports `member` and `assoc` from `(scheme base)`, which allow an extra `compare` argument which the R6RS variants don't.

control: Trivial.