### PR TITLE
Implemented (r6rs sorting) for R7RS systems.

### DIFF
--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -19,7 +19,7 @@ List of R6RS standard libraries and their current status:
 (r6rs unicode)                  fully implemented atop (scheme char)
 (r6rs bytevectors)              fully implemented atop (scheme base)
 (r6rs lists)                    fully implemented atop (scheme base)
-(r6rs sorting)                  not yet implemented
+(r6rs sorting)                  fully implemented atop (scheme base)
 (r6rs control)                  fully implemented atop (scheme base)
 (r6rs records syntactic)        will wait for R7RS (large)
 (r6rs records procedural)       will wait for R7RS (large)

--- a/tools/R6RS/r6rs/sorting.body.scm
+++ b/tools/R6RS/r6rs/sorting.body.scm
@@ -1,0 +1,82 @@
+;;; Copyright 2015 Taylan Ulrich Bayırlı/Kammer <taylanbayirli@gmail.com>.
+;;;
+;;; Permission to copy this software, in whole or in part, to use this
+;;; software for any lawful purpose, and to redistribute this software
+;;; is granted subject to the restriction that all copies made of this
+;;; software must include this copyright and permission notice in full.
+;;;
+;;; I also request that you send me a copy of any improvements that you
+;;; make to this software so that they may be incorporated within it to
+;;; the benefit of the Scheme community.
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (list-sort compare lst)
+  (define (merge left right)
+    (let loop ((left left)
+               (right right)
+               (result '()))
+      (cond
+       ((and (null? left) (null? right))
+        (reverse result))
+       ((null? left)
+        (loop left (cdr right) (cons (car right) result)))
+       ((null? right)
+        (loop (cdr left) right (cons (car left) result)))
+       (else
+        (let ((left1 (car left))
+              (right1 (car right)))
+          (if (compare left1 right1)
+              (loop (cdr left) right (cons left1 result))
+              (loop left (cdr right) (cons right1 result))))))))
+  (define (pair-map! proc lst)
+    ;; { a, b, c, d[, e] } -> f -> { f(a, b), f(c, d)[, e] }
+    (unless (or (null? lst) (null? (cdr lst)))
+      (let ((first (car lst))
+            (second (car (cdr lst)))
+            (rest (cdr (cdr lst))))
+        (set-car! lst (proc first second))
+        (set-cdr! lst rest)
+        (pair-map! proc rest))))
+  (if (or (null? lst) (null? (cdr lst)))
+      lst
+      (let ((sublists (map list lst)))
+        (do ()
+            ((null? (cdr sublists))
+             (car sublists))
+          (pair-map! merge sublists)))))
+
+;;; This must not mutate the return value of previous returns in case of
+;;; multiple returns, so we can't copy & in-place-sort.
+(define (vector-sort compare vector)
+  (list->vector (list-sort compare (vector->list vector))))
+
+(define (vector-sort! compare vector)
+  (define (ref i) (vector-ref vector i))
+  (define (set i obj) (vector-set! vector i obj))
+  (define (swap i j)
+    (let ((i-val (ref i))
+          (j-val (ref j)))
+      (set i j-val)
+      (set j i-val)))
+  (define (partition from to)
+    (let* ((pivot-index (floor-quotient (+ from to) 2))
+           (pivot-value (ref pivot-index)))
+      (swap pivot-index to)
+      (do ((i from (+ i 1))
+           (left from (if (compare (ref i) pivot-value)
+                          (begin (swap i left)
+                                 (+ left 1))
+                          left)))
+          ((= i to)
+           (swap left to)
+           (do ((right left (+ right 1)))
+               ((or (= right to)
+                    (compare pivot-value (ref right)))
+                (values left right)))))))
+  (define (quicksort from to)
+    (when (< from to)
+      (let-values (((left right) (partition from to)))
+        (quicksort from left)
+        (quicksort right to))))
+  (quicksort 0 (- (vector-length vector) 1)))

--- a/tools/R6RS/r6rs/sorting.sld
+++ b/tools/R6RS/r6rs/sorting.sld
@@ -1,0 +1,4 @@
+(define-library (r6rs sorting)
+  (export list-sort vector-sort vector-sort!)
+  (import (scheme base))
+  (include "sorting.body.scm"))


### PR DESCRIPTION
Fairly straightforward merge sort for non-mutating and quicksort for mutating/in-place sort.

Non-mutating vector sort is specified to not mutate the return values of previous returns in case of multiple returns, so we do `vector->list` + merge sort + `list->vector` instead of copying & in-place sorting.

Quicksort handles repeated elements but is otherwise fairly simplistic (always chooses middle index as the pivot, doesn't use insertion sort).