### PR TITLE
Implemented (r6rs exceptions) for R7RS systems.

### DIFF
--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -27,7 +27,7 @@ List of R6RS standard libraries and their current status:
 (r6rs exceptions)               fully implemented atop (scheme base)
 (r6rs conditions)               won't be implemented
 (r6rs io ports)                 not yet implemented
-(r6rs io simple)                not yet implemented
+(r6rs io simple)                fully implemented atop (scheme *)
 (r6rs files)                    fully implemented atop (scheme file)
 (r6rs programs)                 fully implemented atop (scheme process-context)
 (r6rs arithmetic fixnums)       not yet implemented

--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -24,7 +24,7 @@ List of R6RS standard libraries and their current status:
 (r6rs records syntactic)        will wait for R7RS (large)
 (r6rs records procedural)       will wait for R7RS (large)
 (r6rs records inspection)       will wait for R7RS (large)
-(r6rs exceptions)               not yet implemented
+(r6rs exceptions)               fully implemented atop (scheme base)
 (r6rs conditions)               won't be implemented
 (r6rs io ports)                 not yet implemented
 (r6rs io simple)                not yet implemented

--- a/tools/R6RS/README
+++ b/tools/R6RS/README
@@ -37,7 +37,7 @@ List of R6RS standard libraries and their current status:
 (r6rs hashtables)               fully implemented atop (srfi 69) or nada
 (r6rs enums)                    not yet implemented
 (r6rs)                          not yet implemented
-(r6rs eval)                     not yet implemented
+(r6rs eval)                     fully implemented atop (scheme eval)
 (r6rs mutable-pairs)            fully implemented atop (scheme base)
 (r6rs mutable-strings)          fully implemented atop (scheme base)
 (r6rs r5rs)                     not yet implemented

--- a/tools/R6RS/r6rs/eval.sld
+++ b/tools/R6RS/r6rs/eval.sld
@@ -1,0 +1,3 @@
+(define-library (r6rs eval)
+  (export eval environment)
+  (import (scheme eval)))

--- a/tools/R6RS/r6rs/exceptions.sld
+++ b/tools/R6RS/r6rs/exceptions.sld
@@ -1,0 +1,3 @@
+(define-library (r6rs exceptions)
+  (export with-exception-handler guard raise raise-continuable)
+  (import (scheme base)))

--- a/tools/R6RS/r6rs/io/simple.sld
+++ b/tools/R6RS/r6rs/io/simple.sld
@@ -1,0 +1,16 @@
+(define-library (r6rs io simple)
+  (export
+   eof-object eof-object?
+   call-with-input-file call-with-output-file
+   input-port? output-port?
+   current-input-port current-output-port current-error-port
+   with-input-from-file with-output-to-file
+   open-input-file open-output-file
+   close-input-port close-output-port
+   read-char peek-char read
+   write-char newline display write)
+  (import
+   (scheme base)
+   (scheme file)
+   (scheme read)
+   (scheme write)))


### PR DESCRIPTION
Note on `raise`: R6RS specifies that it should raise a `&non-continuable` condition if the exception handler returns.  R7RS leaves it unspecified what it raises.  I assume that a competent R7RS implementation, if it supports the condition system of R6RS, will make its `raise` from `(scheme base)` conformant to R6RS, so it's fine for us to simply re-export it for this library.