### PR TITLE
Fix SRFI-123 for compile-r7rs-runtime

### DIFF
--- a/lib/SRFI/srfi/123.sld
+++ b/lib/SRFI/srfi/123.sld
@@ -6,10 +6,14 @@
   (import
    (except (scheme base) set! define-record-type)
    (scheme case-lambda)
-   (r6rs hashtables)
    (srfi 1)
    (srfi 17)
    (srfi 31))
+  (cond-expand
+   ((library (r6rs hashtables))
+    (import (r6rs hashtables)))
+   ((library (rnrs hashtables))
+    (import (rnrs hashtables))))
   (cond-expand
    ;; Favor SRFI-99.
    ((library (srfi 99))


### PR DESCRIPTION
It seems `compile-r7rs-runtime` does not search libraries on `tools/` directory. Use `(rnrs hashtables)` library if `(r6rs hashtables)` was not found.