### PR TITLE
Add make templates for gcc6 for Petit Larceny

### DIFF
--- a/src/Asm/Standard-C/dumpheap-unix.sch
+++ b/src/Asm/Standard-C/dumpheap-unix.sch
@@ -183,6 +183,8 @@
 			       'petit-unix-static-gcc-v4)
 			      ((match-gcc-version? " 5.")
 			       'petit-unix-static-gcc-v5)
+			      ((match-gcc-version? " 6.")
+			       'petit-unix-static-gcc-v6)
 			      (else
 			       (error 'dumpheap-unix.sch 
 				      "Unmatched GCC version."))

--- a/src/Rts/make-templates.sch
+++ b/src/Rts/make-templates.sch
@@ -93,6 +93,10 @@
      . ,(lambda ()
 	  (values make-template-petit-unix-gcc-v5
 		  make-template-target-petit-unix-shared)))
+    (petit-unix-shared-gcc-v6
+     . ,(lambda ()
+	  (values make-template-petit-unix-gcc-v6
+		  make-template-target-petit-unix-shared)))
     (petit-macosx-shared-gcc
      . ,(lambda ()
 	  (values make-template-petit-macosx-gcc-shared 
@@ -108,6 +112,10 @@
     (petit-unix-static-gcc-v5
      . ,(lambda () 
 	  (values make-template-petit-unix-gcc-v5
+		  make-template-target-petit-unix-static)))
+    (petit-unix-static-gcc-v6
+     . ,(lambda () 
+	  (values make-template-petit-unix-gcc-v6
 		  make-template-target-petit-unix-static)))
     (petit-win32-static-mingw-v3
      . ,(lambda () 
@@ -171,7 +179,7 @@ ASFLAGS   = -I$(INC_ROOT)/ -I$(INC_ROOT)/Sys/ -I$(INC_ROOT)/Shared/
    "CFLAGS+=-c "
    (case version
      ((gcc-v3) " ")
-     ((gcc-v4 gcc-v5) " -fno-stack-protector "))
+     ((gcc-v4 gcc-v5 gcc-v6) " -fno-stack-protector "))
    " -falign-functions=4 -m32 -I$(INC_ROOT)/Standard-C"))
 (define (makefile-variable-definitions version)
   (let ((lines (lambda strings
@@ -193,6 +201,8 @@ ASFLAGS   = -I$(INC_ROOT)/ -I$(INC_ROOT)/Sys/ -I$(INC_ROOT)/Shared/
   (template-common (makefile-variable-definitions 'gcc-v4)))
 (define make-template-petit-unix-gcc-v5
   (template-common (makefile-variable-definitions 'gcc-v5)))
+(define make-template-petit-unix-gcc-v6
+  (template-common (makefile-variable-definitions 'gcc-v6)))
 
 ; Native Larceny with Sassy back-end: Unix: NASM macro assembler for Rts
 (define make-template-sassy-unix-gcc


### PR DESCRIPTION
Follows the pattern of the gcc5 change.  Tested locally on Ubuntu 17.04 with gcc 6.3.0.